### PR TITLE
Fix calculator output formatting

### DIFF
--- a/02_Projetos_Pessoais/Python/Projetos em Python/01_Calculadora/calculadora.py
+++ b/02_Projetos_Pessoais/Python/Projetos em Python/01_Calculadora/calculadora.py
@@ -25,4 +25,5 @@ while True:
     else:
         print('Operação não reconhecida!')
         
-    print('{} {} {} = {.:}'.format(num1, op, num2, result))
+    # Exibe o cálculo realizado de forma legível
+    print(f"{num1} {op} {num2} = {result}")


### PR DESCRIPTION
## Summary
- fix malformed string format in calculator output
- clarify output with comment

## Testing
- `python -m py_compile "02_Projetos_Pessoais/Python/Projetos em Python/01_Calculadora/calculadora.py"`
- `python - <<'PY'
num1=1
op='+'
num2=2
result=num1+num2
print(f"{num1} {op} {num2} = {result}")
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a214cdf1c4832e9afa8635ee3fa901